### PR TITLE
Speed up build time with ensure "WinVerifyTrust" isn't triggered for each project and file while building projects

### DIFF
--- a/src/tools/Rubble/Rubble.psm1
+++ b/src/tools/Rubble/Rubble.psm1
@@ -1,6 +1,6 @@
 $PSScriptRoot = Split-Path  $script:MyInvocation.MyCommand.Path
 
-Get-ChildItem -Path $PSScriptRoot\*.ps1 -Exclude *.tests.ps1 | Foreach-Object{ . $_.FullName }
+Get-ChildItem -Path $PSScriptRoot\*.ps1 -Exclude *.tests.ps1 | Foreach-Object{ . ([scriptblock]::Create([io.file]::ReadAllText($_.FullName))) }
 Export-ModuleMember -Function * -Alias *
 
 function ResolvePath() {


### PR DESCRIPTION
Since few weeks we faced the issue that projects are built much slower then usually. This is a fix for that. 